### PR TITLE
Fix mismatched parameter name

### DIFF
--- a/mackerel/client.py
+++ b/mackerel/client.py
@@ -130,7 +130,7 @@ class Client(object):
         """Get hosts.
 
         :param service: Service name
-        :param roles: Service role
+        :param role: Service role
         :param name: Host name
         """
         uri = '/api/v0/hosts.json'
@@ -138,8 +138,8 @@ class Client(object):
         if kwargs.get('service', None):
             params['service'] = kwargs.get('service')
 
-        if kwargs.get('roles', None):
-            params['roles'] = kwargs.get('roles')
+        if kwargs.get('role', None):
+            params['role'] = kwargs.get('role')
 
         if kwargs.get('name', None):
             params['name'] = kwargs.get('name')


### PR DESCRIPTION
Thank you for your good library! I found a bug and fixed it.

The parameter name for Host-API is role instead of roles.

ref: https://mackerel.io/ja/api-docs/entry/hosts#list